### PR TITLE
Fix SONM icon filename in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -206,7 +206,7 @@
     "sky": "sky",
     "smart": "smart",
     "sngls": "sngls",
-    "snm": "smn",
+    "snm": "sonm",
     "snt": "snt",
     "sphtx": "sphtx",
     "srn": "srn",


### PR DESCRIPTION
The filename for the SONM coin is `sonm.svg`
but
the key value pair in manifest was "snm": "smn",